### PR TITLE
server middleware

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1810,6 +1810,14 @@
         }
       }
     },
+    "@koa/cors": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.1.0.tgz",
+      "integrity": "sha512-7ulRC1da/rBa6kj6P4g2aJfnET3z8Uf3SWu60cjbtxTA5g8lxRdX/Bd2P92EagGwwAhANeNw8T8if99rJliR6Q==",
+      "requires": {
+        "vary": "^1.1.2"
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz",
@@ -2110,10 +2118,36 @@
         "@types/node": "*"
       }
     },
+    "@types/koa-bodyparser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
+      "integrity": "sha512-aB/vwwq4G9FAtKzqZ2p8UHTscXxZvICFKVjuckqxCtkX1Ro7F5KHkTCUqTRZFBgDoEkmeca+bFLI1bIsdPPZTA==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
     "@types/koa-compose": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa-helmet": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/koa-helmet/-/koa-helmet-6.0.1.tgz",
+      "integrity": "sha512-kPdPJFDfQbDqsp6/29yWnzoCz+Wo9MasY9AbaZnyS5AKqHFToviSQkzTl6SENbWem/yTwGER/gbc0Y+/ptvd+w==",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*",
+        "helmet": "^4.0.0"
+      }
+    },
+    "@types/koa__cors": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-2.2.3.tgz",
+      "integrity": "sha512-RfG2EuSc+nv/E+xbDSLW8KCoeri/3AkqwVPuENfF/DctllRoXhooboO//Sw7yFtkLvj7nG7O1H3JcZmoTQz8nQ==",
       "requires": {
         "@types/koa": "*"
       }
@@ -2517,6 +2551,40 @@
             "@types/node": "*",
             "@types/qs": "*",
             "@types/range-parser": "*"
+          }
+        }
+      }
+    },
+    "apollo-server-koa": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-koa/-/apollo-server-koa-2.19.0.tgz",
+      "integrity": "sha512-o9FJWPYxA2ez5ZhERAbXW/L+t00axb/D3B5a9ZBwgIGdGGLABqt7PXfspRM9Opbq1qSTB52f/UWll+vRxoi0cw==",
+      "requires": {
+        "@apollographql/graphql-playground-html": "1.6.26",
+        "@koa/cors": "^2.2.1",
+        "@types/accepts": "^1.3.5",
+        "@types/cors": "^2.8.4",
+        "@types/koa": "^2.0.46",
+        "@types/koa-bodyparser": "^4.2.1",
+        "@types/koa-compose": "^3.2.2",
+        "@types/koa__cors": "^2.2.1",
+        "accepts": "^1.3.5",
+        "apollo-server-core": "^2.19.0",
+        "apollo-server-types": "^0.6.1",
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tools": "^4.0.0",
+        "koa": "2.13.0",
+        "koa-bodyparser": "^4.2.1",
+        "koa-compose": "^4.1.0",
+        "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "@koa/cors": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-2.2.3.tgz",
+          "integrity": "sha512-tCVVXa39ETsit5kGBtEWWimjLn1sDaeu8+0phgb8kT3GmBDZOykkI3ZO8nMjV2p3MGkJI4K5P+bxR8Ztq0bwsA==",
+          "requires": {
+            "vary": "^1.1.2"
           }
         }
       }
@@ -3075,6 +3143,15 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "requires": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      }
+    },
     "call-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
@@ -3351,8 +3428,18 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "co-body": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
+      "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
+      "requires": {
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      }
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -3448,11 +3535,32 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "requires": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
     },
     "core-js": {
       "version": "3.8.0",
@@ -3597,6 +3705,11 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3662,6 +3775,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
@@ -4548,6 +4666,11 @@
         }
       }
     },
+    "helmet": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.2.0.tgz",
+      "integrity": "sha512-aoiSxXMd0ks1ojYpSCFoCRzgv4rY/uB9jKStaw8PkXwsdLYa/Gq+Nc5l0soH0cwBIsLAlujPnx4HLQs+LaXCrQ=="
+    },
     "highlight.js": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz",
@@ -4573,6 +4696,34 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "http-assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.1.tgz",
+      "integrity": "sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==",
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.7.2"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        }
+      }
     },
     "http-errors": {
       "version": "1.8.0",
@@ -4640,6 +4791,11 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
     },
     "inflight": {
       "version": "1.0.6",
@@ -4810,6 +4966,11 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -6684,6 +6845,14 @@
         "verror": "1.10.0"
       }
     },
+    "keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6695,6 +6864,87 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "koa": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.0.tgz",
+      "integrity": "sha512-i/XJVOfPw7npbMv67+bOeXr3gPqOAw6uh5wFyNs3QvJ47tUx3M3V9rIE0//WytY42MKz4l/MXKyGkQ2LQTfLUQ==",
+      "requires": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.8.0",
+        "debug": "~3.1.0",
+        "delegates": "^1.0.0",
+        "depd": "^1.1.2",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^1.2.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "koa-bodyparser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
+      "integrity": "sha512-uyV8G29KAGwZc4q/0WUAjH+Tsmuv9ImfBUF2oZVyZtaeo0husInagyn/JH85xMSxM0hEk/mbCII5ubLDuqW/Rw==",
+      "requires": {
+        "co-body": "^6.0.0",
+        "copy-to": "^2.0.1"
+      }
+    },
+    "koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
+    },
+    "koa-convert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
+      "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+      "requires": {
+        "co": "^4.6.0",
+        "koa-compose": "^3.0.0"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "^1.1.0"
+          }
+        }
+      }
+    },
+    "koa-helmet": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/koa-helmet/-/koa-helmet-6.0.0.tgz",
+      "integrity": "sha512-W7HSrf3FtCGFy1EdzEk4qOIIJrzms2QSv0/QQ6aZVoDUgPTRZAxdAQNSPgDHSxVjK3zyGv2vwZhgc0FJPdk0+g==",
+      "requires": {
+        "helmet": "^4.1.1"
+      }
     },
     "leven": {
       "version": "3.1.0",
@@ -7318,6 +7568,11 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -7728,8 +7983,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -8988,6 +9242,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -9654,6 +9913,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "ylru": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
+      "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ=="
     },
     "yn": {
       "version": "3.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-typescript": "^7.12.7",
     "@types/jest": "^26.0.15",
+    "@types/koa-helmet": "^6.0.1",
     "@types/node": "^14.14.10",
     "babel-jest": "^26.6.3",
     "babel-plugin-module-resolver": "^4.0.0",
@@ -31,8 +32,12 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
+    "@koa/cors": "^3.1.0",
     "apollo-server": "^2.19.0",
+    "apollo-server-koa": "^2.19.0",
     "graphql": "^15.4.0",
+    "koa": "^2.13.0",
+    "koa-helmet": "^6.0.0",
     "pg": "^8.5.1",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.29"

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,7 @@
-import {ApolloServer} from 'apollo-server';
+import cors from '@koa/cors';
+import {ApolloServer} from 'apollo-server-koa';
+import Koa from 'koa';
+import helmet from 'koa-helmet';
 import 'reflect-metadata'; // required for typeorm
 import {createConnection} from 'typeorm';
 import {resolvers} from './resolvers';
@@ -12,8 +15,20 @@ createConnection()
       context: {connection},
     });
 
-    server.listen().then(({url}) => {
-      console.log(`🚀 Apollo server ready at ${url}`);
+    const app = new Koa();
+
+    app.use(
+      helmet({
+        contentSecurityPolicy:
+          process.env.NODE_ENV === 'production' ? undefined : false,
+      }),
+    );
+    app.use(cors({origin: '*'}));
+
+    server.applyMiddleware({app});
+
+    app.listen(8000, () => {
+      console.log(`🚀 on ${8000}`);
     });
   })
   .catch(error => console.error(error));


### PR DESCRIPTION
This PR creates a `koa` server to be used within Apollo. This is required to be able to add our own middleware to the server.

It also adds the `CORS` middleware and the `helmet` middleware which adds some default headers for security.